### PR TITLE
Allow other file format in the reply.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,14 @@ Crowdin.prototype.requestData = function(params) {
     })
     // Parse JSON
     .then(function(body) {
-        if (body) return JSON.parse(body);
+        if (body) {
+            try {
+                return JSON.parse(body);
+            }
+            catch (e) {
+                return body;
+            }
+        }
         return {};
     })
     // Throw error if present


### PR DESCRIPTION
In my case we are trying to fetch csv file format that for some weird reason crowding does not convert to json.
