### PR TITLE
fix buffering issue with multibyte symbols

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,19 +132,19 @@ Crowdin.prototype.downloadToObject = function() {
 
     var parseEntry = function(ext, entry) {
         return new Promise(function(resolve, reject) {
-            var buffer = '';
+            var buffer = new Buffer(0);
 
             entry
             .on('error', reject)
             .on('data', function(chunk) {
-                buffer += chunk.toString();
+                buffer = Buffer.concat([buffer, chunk]);
             })
             .on('end', function() {
                 var lang = entry.path.split('/')[0];
                 var values = {};
 
-                if (ext === '.json') values[ lang ] = JSON.parse(buffer);
-                else values[ lang ] = yaml.safeLoad(buffer); // YAML
+                if (ext === '.json') values[ lang ] = JSON.parse(buffer.toString());
+                else values[ lang ] = yaml.safeLoad(buffer.toString()); // YAML
 
                 resolve(values);
             });


### PR DESCRIPTION
An issue showed up when using this package with a Crowdin project that has a multibyte language as one if its localisations (In my case it was Japanese).

The fix is implemented via buffer concatenation as opposed to parsing chunks into strings and then concacting that (if the buffer cuts a characters bytes the parsed string looses some data on its ends). 
